### PR TITLE
Bootstrap component styling + start of custom component style

### DIFF
--- a/src/utils/custom-styles.scss
+++ b/src/utils/custom-styles.scss
@@ -6,7 +6,7 @@
 @each $color, $value in $theme-colors {
     .alert-#{$color} {
       color: $black;
-     box-shadow: $box-shadow-sm;
+     box-shadow: $dropdown-box-shadow;
     }
   
     .alert-icon.alert-#{$color} {
@@ -28,45 +28,254 @@
       .alert-icon.alert-dismissible .message{
           padding: $alert-padding-y 4rem $alert-padding-y $alert-padding-x;
       }
+}
+  
+.alert-icon-border {
+    background-color: $white;
+}
+
+//Forms
+
+.form-control {
+    border-radius: $border-radius-sm;
+}
+
+.switch {
+    position: relative;
+    display: inline-block;
+    width: 35px;
+    height: 21px;
   }
   
-  .alert-icon-border {
-      background-color: $white;
+  .switch input {display:none;}
+  
+  .slider {
+    position: absolute;
+    cursor: pointer;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: #ccc;
+    -webkit-transition: .4s;
+    transition: .4s;
+    border: 2px solid #666666;
   }
   
-  //Cards
-  
-  .card {
-      box-shadow: $box-shadow-sm;
+  .slider:before {
+    position: absolute;
+    content: "";
+    height: 16px;
+    width: 16px;
+    left: 1px;
+    bottom: 1px;
+    background-color: white;
+    -webkit-transition: .4s;
+    transition: .4s;
   }
   
-  .card-header, .card-footer {
-      background: transparent;
-      margin: 0 $card-spacer-x;
-      padding: $card-spacer-y 0;
+  input:checked + .slider {
+    background-color: #FEC04F;
   }
   
-  a .card {
-      text-decoration: none;
+  input:focus + .slider {
+    box-shadow: 0 0 1px #2196F3;
   }
   
-  //Menus
-  
-  a.dropdown-item {
-      text-decoration: none;
+  input:checked + .slider:before {
+    -webkit-transform: translateX(14px);
+    -ms-transform: translateX(14px);
+    transform: translateX(14px);
   }
   
-  .dropdown-divider {
-      margin:0;
-  }
+  /* Rounded sliders */
+  .slider.round {
+    border-radius: 34px;
+    }							
   
-  //Helper Classes
-  
-  .bd-example {
-      position: relative;
+  .slider.round:before {
+    border-radius: 50%;
   }
+
+
+//Cards
   
-  .bd-example>.dropdown-menu:first-child {
-      position: static;
-      display: block;
+.card {
+    box-shadow: $dropdown-box-shadow;
+    border-radius: $border-radius-lg;
+}
+  
+.card-header, .card-footer {
+    background: transparent;
+    margin: 0 $card-spacer-x;
+    padding: $card-spacer-y 0;
+}
+  
+a .card {
+    text-decoration: none;
+}
+
+.card-profile {
+    display: flex;
+}
+
+.card-profile .card-body {
+    flex: 1;
+}
+
+.card-profile .avatar {
+    margin-top: -70px;
+    width: 90px;
+    height: 90px;
+}
+  
+//Menus
+.dropdown-menu {
+    border-radius: $border-radius-sm;
+}  
+a.dropdown-item {
+    text-decoration: none;
+}
+  
+.dropdown-divider {
+    margin:0;
+}
+
+//Navbars
+
+.navbar a {
+    text-decoration: none !important;
+}
+
+.navbar-brand {
+    margin-right: 3rem;
+}
+
+.navbar-light .nav-item:hover {
+    background-color: $gray-200;
+    border-radius: $border-radius;
+}
+
+.navbar-light .nav-item.active {
+    background-color: $gray-200;
+    border-radius: $border-radius;
+}
+
+.navbar-dark .nav-item.active {
+    background-color: rgba(255,255,255, 0.15);
+    border-radius: $border-radius;
+}
+
+.navbar-dark .nav-item:hover {
+    background-color: rgba(255,255,255, 0.15);
+    border-radius: $border-radius;
+}
+
+//Nav Tabs
+
+.nav-tabs .nav-link {
+    text-decoration: none;
+    padding: $nav-link-padding-y $nav-link-padding-x .2rem $nav-link-padding-x;
+}
+
+.nav-tabs .nav-link.active {
+    font-weight: bold;
+}
+  
+//Modals
+.modal-header, .modal-footer {
+    border: none;
+}
+
+//Helper Classes
+  
+.bd-example {
+    position: relative;
+}
+  
+.bd-example>.dropdown-menu:first-child {
+    position: static;
+    display: block;
+}
+
+//Avatars
+
+.avatar {
+    width: 50px;
+    height: 50px;
+    border-radius: $border-radius-sm;
+    background: #F7F9FA;
+    color: #fff;
+}
+
+.avatar.avatar-sm {
+    width: 26px;
+    height: 26px; 
+}
+
+.avatar.avatar-lg {
+    width: 115px;
+    height: 115px;
+}
+
+.media .avatar {
+    margin-right: 15px;
+}
+
+//Media
+
+.media.media-comment {
+    margin: 1rem 0;
+}
+.media .media-footer {
+    margin-top: 5px;
+}
+
+.media.media-nested-comment {
+    margin: 0.75rem 0;
+    border-left: 1px solid $primary;
+    padding-left: 1rem;
+}
+
+//Tags / Badges
+
+.badge-tag {
+    position: relative;
+    padding-left: 16px;
+    padding-bottom: 6px;
+    margin-left: 10px;
+}
+
+.badge-tag::before {
+    background: #fff;
+    border-radius: 10px;
+    box-shadow: inset 0 1px rgba(0, 0, 0, 0.25);
+    content: '';
+    height: 6px;
+    left: 3px;
+    position: absolute;
+    width: 6px;
+    top: 10px; 
+}
+
+.badge-tag::after {
+    border-bottom: 13px solid transparent;
+    border-right: 10px solid #2C73A1;
+    border-top: 13px solid transparent;
+    content: '';
+    position: absolute;
+    left: -8px;
+    top: 0;
+    width: 0;
+    height: 0;
+    border-radius: 20px;
   }
+
+  //Table
+
+  .table thead th {
+      border-bottom: 3px solid #96A8B2;
+      border-top: none;
+  }
+
+  

--- a/src/utils/custom-variables.scss
+++ b/src/utils/custom-variables.scss
@@ -15,24 +15,27 @@
 $enable-shadows: true;
 //$enable-gradients: true;
 
-//$link-decoration: underline;
+$link-decoration: none;
 
 // Changing the body background and text
 //$body-bg: #d3e9eb;
 //$body-color: #151417;
 
 // Changing the border radius of buttons
-$border-radius: 2px;
+$border-radius: .35rem;
+$border-radius-lg: .5rem;
 
 // Changing the theme colors
-$primary: #e79a0a;
-$secondary: #4d5d6c;
+$primary: #2C73A1;
+$secondary: #0ba7b4;
 $success: #278400;
 $info: #269abc;
 $warning: #ff9900;
 $danger: #d3080c;
 $light: #FFFFFF;
 //$dark: #0f1319;
+
+$body-bg: #FAFAFA;
 
 //Alerts
 $alert-bg-level: -12;
@@ -42,7 +45,7 @@ $alert-bg-level: -12;
 $input-border-color: #CCCCCC;
 $input-box-shadow: 0px 0px 2px rgba(0, 0, 0, 0.2);
 $input-focus-border-color: #269abc;
-$input-focus-box-shadow: none;
+$input-focus-box-shadow: 0px 0px 2px rgba(38, 154, 188, 0.7);
 
 $label-margin-bottom: 0.2rem;
 
@@ -50,6 +53,10 @@ $custom-checkbox-indicator-icon-checked: white;
 $custom-checkbox-indicator-icon-indeterminate: none;
 $custom-checkbox-indicator-indeterminate-color: white;
 
+//Badges
+
+$badge-font-size: 100%;
+$badge-font-weight: normal;
 
 //Buttons
 
@@ -62,17 +69,45 @@ $breadcrumb-divider: quote(">");
 //Cards
 
 $card-spacer-x: 0.75rem;
+$card-border-width: 0px;
 
 //Dropdowns
 
 $dropdown-border-color: #cccccc;
-$dropdown-box-shadow: 1px 1px 2px rgba(0, 0, 0, 0.4);
+$dropdown-box-shadow: 0px 0px 5px rgba(0, 0, 0, 0.15);
 $dropdown-divider-bg:  #d7d7d7;
 $dropdown-padding-y: 0;
 
 $dropdown-link-hover-bg: #e6e6e6;
 
 $dropdown-item-padding-y: .5rem;
+
+//Modals
+
+$modal-content-border-radius: 2px;
+
+
+//Navbar
+
+$navbar-nav-link-padding-x: .75rem;
+$navbar-light-color: black;
+$navbar-light-hover-color: black;
+$navbar-dark-color: white;
+$navbar-dark-hover-color: white;
+
+//Tabs
+
+$nav-tabs-border-color: #cccccc;
+$nav-tabs-border-width: 2px;
+$nav-tabs-link-active-border-color: transparent transparent #002d42;
+$nav-tabs-link-hover-border-color: transparent transparent #002d42;
+
+//Tables
+
+$table-border-color: #96A8B2;
+$table-hover-bg: #F2F5F6;
+$table-accent-bg: #F2F5F6;
+
 // Adding (!) an additional theme color (ex. classes btn-cool, bg-cool)
 //$theme-colors: (
 //  "cool": #4d3fa3


### PR DESCRIPTION
Overriding Bootstrap SASS to style the standard Bootstrap UI components to match design system documentation + ui kit design. 

This is only to create a style sheet of the basic components and the start of some of our custom components as well. The goal is the exported .css file can be used essentially as a Bootstrap theme and used with Bootstrap React libraries.

This still needs cleaning up that I will do a bit later 👌 

https://github.com/gctools-outilsgc/design-system/issues/194