### PR TITLE
Provide context to examples

### DIFF
--- a/src/docs/en/component/buttons.md
+++ b/src/docs/en/component/buttons.md
@@ -42,7 +42,7 @@ Buttons should include normal, hover, focus, active and disabled states:
 
 **Focus:** Similar to hover states, focus states indicate that the user has tabbed to the specific button.
 
-**Active/Pressed:** Usually indicated by a change in colour or animation, this indicates that the user has clicked or pressed a button/
+**Active/Pressed:** Usually indicated by a change in colour or animation, this indicates that the user has clicked or pressed a button
 
 **Disabled:** Usually a ghosted version of the normal state, this indicates to the user that the action is unavailable.
 
@@ -58,20 +58,20 @@ Each of the states for primary buttons are as follows:
 
 **Regular state:** primary colour at 100% opacity, white text, with a border radius of 4px and padding of 15px.
 
-<button color="primary">Regular</button>
+<button aria-label="Example of primary button in regular state" color="primary">Regular</button>
 <codeblock html='<button type="button" class="btn btn-primary">Primary</button>' react='<Button color="primary">Primary</Button>'></codeblock>
 
 **Hover state:** primary colour at 80% opacity, white text, with a border radius of 4px and padding of 15px.
 
-<button color="primary" style="color: #fff; background-color: #245e83; border-color: #215679">Hover</button>
+<button aria-label="Example of primary button in hover state" color="primary" style="color: #fff; background-color: #245e83; border-color: #215679">Hover</button>
 
 **Focus state:** primary colour at 80% opacity, white text, with a border radius of 4px and padding of 15px. Includes a 3px stroke in the primary colour.
 
-<button color="primary" style="outline: 1px dotted; outline: 5px auto -webkit-focus-ring-color;">Focus</button>
+<button aria-label="Example of primary button in focus state" color="primary" style="background-color: #002D42; box-shadow: 0 0 0 0.2rem rgba(0, 45, 66, 0.25);">Focus</button>
 
 **Disabled state:** primary colour at 60% opacity, white text, with a border radius of 4px and padding of 15px.
 
-<button color="primary" disabled="true">Disabled</button>
+<button aria-label="Example of primary button in disabled state" color="primary" disabled="true">Disabled</button>
 <codeblock html='
     <button type="button" class="btn btn-primary" disabled>Disabled</button>
 ' react=''></codeblock>
@@ -92,21 +92,23 @@ Secondary buttons in this system are transparent with a stroke colour. Text chan
 
 Each of the states for secondary buttons are as follows:
 
-**Regular state:** transparent with a 1px stroke using the  colour <badge style="background-color: ##002D42;">##002D42</badge>, the text is written in the same colour. Border radius of 4px and padding of 15px.
+**Regular state:** transparent with a 1px stroke using the  colour <badge style="background-color: #002D42;">#002D42</badge>, the text is written in the same colour. Border radius of 4px and padding of 15px.
 
-<button color="secondary">Regular</button>
+<button aria-label="Example of secondary button in regular state" color="secondary">Regular</button>
 
 <codeblock html='<button type="button" class="btn btn-secondary">Secondary</button>' react='<Button color="secondary">Secondary</Button>'></codeblock>
 
-**Hover state:** rectangle coloured with <badge style="background-color: ##002D42;">##002D42</badge> at 80% opacity, the text is displayed in white. Border radius of 4px and padding of 15px.
+**Hover state:** rectangle coloured with <badge style="background-color:#002D42;">#002D42</badge> at 80% opacity, the text is displayed in white. Border radius of 4px and padding of 15px.
 
-**Focus state:** transparent with a 3px stroke using <badge style="background-color: #0ba7b4;">#0ba7b4</badge>, the text is displayed in <badge style="background-color: #fff; color: black;">#fff</badge>. Border radius of 4px and padding of 15px.
+<button aria-label="Example of secondary button in hover state" color="secondary" style="background-color:#002D42; color:white;">Hover</button>
 
-<button color="secondary" style="outline: 1px dotted; outline: 5px auto -webkit-focus-ring-color;">Focus</button>
+**Focus state:** transparent with a 3px stroke using <badge style="background-color: #002d42;">#002d42</badge>, the text is displayed in <badge style="background-color: #fff; color: black;">#FFFFFF</badge>. Border radius of 4px and padding of 15px.
+
+<button aria-label="Example of secondary button in focus state" color="secondary" style="color: #002D42; background-color: transparent; box-shadow: 0 0 0 0.2rem rgba(0, 45, 66, 0.25);">Focus</button>
 
 **Disabled state:** Fill colour of <badge style="background-color: #CECECE;color:black;">#CECECE</badge>, with white text. Border radius of 4px and padding of 15px.
 
-<button color="secondary" disabled="true">Disabled</button>
+<button aria-label="Example of secondary button in disabled state" color="secondary" disabled="true">Disabled</button>
 
 <codeblock html='<button type="button" class="btn btn-secondary" disabled>Secondary</button>' react='<Button color="secondary" disabled>Secondary</Button>'></codeblock>
 
@@ -155,7 +157,7 @@ Drop down buttons display a list of items when clicked. They are used for two-st
 
 **Focus State:** Similar to the primary button, drop-down buttons use the primary colour at 100% opacity, white text, with a border radius of 4px and padding of 15px. The drop-down arrow represents a space of 30px by 40px, which is separated from the primary button using a white line. The arrow uses a space of 15px width and 8px in height. Whichever piece of the button \(primary or drop-down section\) is being focused on is shown at 80% opacity and includes a stroke of 3px in the primary colour.
 
-<mdbuttondropdown color="primary" style="outline: 1px dotted; outline: 5px auto -webkit-focus-ring-color;" title="Focus">
+<mdbuttondropdown color="primary" style=" box-shadow: 0 0 0 0.2rem rgba(0, 45, 66, 0.25);" title="Focus">
 </mdbuttondropdown>
 
 **Pressed State:** When the drop-down arrow is pressed, this arrow section of the button is displayed at 80% opacity and a drop-down menu is displayed below. The action box uses a 1px border using <badge style="background-color: #CECECE;color:black;">#CECECE</badge>. The box has a border radius of 4px. The width of the box is 166px, and the height depends on the number of actions, using 40px per action. On hover, the 40px around the action is displayed using <badge style="background-color: #CECECE;color:black;">#CECECE</badge>.

--- a/src/docs/en/component/buttons.md
+++ b/src/docs/en/component/buttons.md
@@ -67,11 +67,7 @@ Each of the states for primary buttons are as follows:
 
 **Focus state:** primary colour at 80% opacity, white text, with a border radius of 4px and padding of 15px. Includes a 3px stroke in the primary colour.
 
-<button color="primary" disabled="true">Primary</button>
-
 <button color="primary" style="outline: 1px dotted; outline: 5px auto -webkit-focus-ring-color;">Focus</button>
-
-<button color="primary" style="color: #fff; background-color: #215679; border-color: #1e4f6f;box-shadow: 0 0 0 0.2rem rgba(44, 115, 161, 0.25), inset 0 3px 5px rgba(0, 0, 0, 0.125);">Active</button>
 
 **Disabled state:** primary colour at 60% opacity, white text, with a border radius of 4px and padding of 15px.
 

--- a/src/docs/en/component/progress-indicators.md
+++ b/src/docs/en/component/progress-indicators.md
@@ -91,10 +91,10 @@ Progress bars start empty and gradually fill with colour using an animation. The
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 </helmet>
-<i class="fa fa-circle-o-notch fa-spin" style="font-size:24px"><span class="sr-only">Notch circle spinner</span></i>
-<i class="fa fa-refresh fa-spin" style="font-size:24px"><span class="sr-only">Refresh spinner</span></i>
-<i class="fa fa-spinner fa-spin" style="font-size:24px"><span class="sr-only">Dot spinner</span></i>
+<i class="fa fa-circle-o-notch fa-spin" style="font-size:24px"><span class="sr-only">Example of notch circle spinner</span></i>
+<i class="fa fa-refresh fa-spin" style="font-size:24px"><span class="sr-only">Example of refresh spinner</span></i>
+<i class="fa fa-spinner fa-spin" style="font-size:24px"><span class="sr-only">Example of dot spinner</span></i>
 
 Spinners are used to indicate that a page or function is loading. A general rule is to use spinners for processes that take less than 4 seconds. Spinners show indeterminate levels of progress, meaning there is no clear completion and the animation loops until the process is complete.
 
-The spinner used in this design system is displayed using the spinner icon from Font Awesome. Font Awesome provides multiple icons that may work well as a spinner, depending on your content. You can refer to [Font Awesome's documentation](https://www.gitbook.com/book/gctools-outilsgc/-gcdigital-design-system/edit) to animate the spinner to demonstrate a loading page or function.
+The spinner used in this design system is displayed using the spinner icon from Font Awesome. Font Awesome provides multiple icons that may work well as a spinner, depending on your content. You can refer to [Font Awesome's documentation](https://fontawesome.com/how-to-use/on-the-web/styling/animating-icons) to animate the spinner to demonstrate a loading page or function.

--- a/src/docs/en/component/progress-indicators.md
+++ b/src/docs/en/component/progress-indicators.md
@@ -52,32 +52,32 @@ Progress bars are styled using a rectangle with 16px height and variable width. 
 Percentage can be either aligned to the right of the bar, or the percentage can be centred within the coloured portion of the bar.
 
 <div class="progress">
-  <div class="progress-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
+  <div class="progress-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">0%</div>
 </div>
 
 <codeblock html='
     <div class="progress">
-        <div class="progress-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
+        <div class="progress-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">0%</div>
     </div>
 ' react='' />
 
 <div class="progress">
-  <div class="progress-bar" role="progressbar" style="width: 75%" aria-valuenow="75" aria-valuemin="0" aria-valuemax="100"></div>
+  <div class="progress-bar" role="progressbar" style="width: 75%" aria-valuenow="75" aria-valuemin="0" aria-valuemax="100">75%</div>
 </div>
 
 <codeblock html='
     <div class="progress">
-        <div class="progress-bar" role="progressbar" style="width: 75%" aria-valuenow="75" aria-valuemin="0" aria-valuemax="100"></div>
+        <div class="progress-bar" role="progressbar" style="width: 75%" aria-valuenow="75" aria-valuemin="0" aria-valuemax="100">75%</div>
     </div>
 ' react='' />
 
 <div class="progress">
-  <div class="progress-bar" role="progressbar" style="width: 100%" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100"></div>
+  <div class="progress-bar" role="progressbar" style="width: 100%" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100">100%</div>
 </div>
 
 <codeblock html='
     <div class="progress">
-        <div class="progress-bar" role="progressbar" style="width: 100%" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100"></div>
+        <div class="progress-bar" role="progressbar" style="width: 100%" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100">100%</div>
     </div>
 ' react='' />
 
@@ -91,9 +91,9 @@ Progress bars start empty and gradually fill with colour using an animation. The
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 </helmet>
-<i class="fa fa-circle-o-notch fa-spin" style="font-size:24px"></i>
-<i class="fa fa-refresh fa-spin" style="font-size:24px"></i>
-<i class="fa fa-spinner fa-spin" style="font-size:24px"></i>
+<i class="fa fa-circle-o-notch fa-spin" style="font-size:24px"><span class="sr-only">Notch circle spinner</span></i>
+<i class="fa fa-refresh fa-spin" style="font-size:24px"><span class="sr-only">Refresh spinner</span></i>
+<i class="fa fa-spinner fa-spin" style="font-size:24px"><span class="sr-only">Dot spinner</span></i>
 
 Spinners are used to indicate that a page or function is loading. A general rule is to use spinners for processes that take less than 4 seconds. Spinners show indeterminate levels of progress, meaning there is no clear completion and the animation loops until the process is complete.
 

--- a/src/docs/en/component/typography.md
+++ b/src/docs/en/component/typography.md
@@ -166,4 +166,3 @@ Button text is displayed as Nunito Sans Bold at 16 points, and uses the colours 
 <button color="secondary" outline="true">Secondary</button>
 <button color="secondary">Secondary</button>
 <button color="secondary" disabled="true">Secondary</button>
-

--- a/src/docs/en/data/choosing-visualizations.md
+++ b/src/docs/en/data/choosing-visualizations.md
@@ -13,8 +13,6 @@ title: "Choosing visualizations"
 
 ## Tables
 
-<strippedtable></strippedtable>
-
 Tables are a raw format for displaying data sets. If a more complex visualization is used, a table should also be present somewhere on the page so users can choose how they view and analyze data.
 
 Tables may be all you need to visualize your data. Simply using a table is great if:

--- a/src/docs/en/data/data-tables.md
+++ b/src/docs/en/data/data-tables.md
@@ -29,6 +29,7 @@ Header Row: Table headers are displayed in heading 6 (Nunito Sans Bold at 16px) 
 
 Table Cell: Table cell information is displayed using regular text style (Nunito Sans Regular at 16px) and are left aligned. The text has a padding of 21px by 27px. The heading row has a bottom border of 2px using the colour <badge style="background-color: #96a8b2;color:black">#96a8b2</badge>. Each row has a bottom border of 1px using the colour <badge style="background-color: #96a8b2;color:black">#96a8b2</badge>.
 
+<h3>Simple Table Example</h3>
 <table class="table">
   <thead>
     <tr>
@@ -90,7 +91,7 @@ Table Cell: Table cell information is displayed using regular text style (Nunito
             <td>@twitter</td>
             </tr>
         </tbody>
-    </table> 
+    </table>
 ' react=''></codeblock>
 
 ## Striped Table
@@ -107,6 +108,7 @@ Table Cell: Table cell information is displayed using regular text style (Nunito
 
 Every second row has a fill of <badge style="background-color: #F2F5F6;color:black">#F2F5F6</badge>.
 
+<h3>Stripped Table Example</h3>
 <strippedtable></strippedtable>
 
 <codeblock html='

--- a/src/docs/en/data/data-tables.md
+++ b/src/docs/en/data/data-tables.md
@@ -108,7 +108,7 @@ Table Cell: Table cell information is displayed using regular text style (Nunito
 
 Every second row has a fill of <badge style="background-color: #F2F5F6;color:black">#F2F5F6</badge>.
 
-<h3>Stripped Table Example</h3>
+<h3>Striped Table Example</h3>
 <strippedtable></strippedtable>
 
 <codeblock html='

--- a/src/docs/fr/component/boutons.md
+++ b/src/docs/fr/component/boutons.md
@@ -56,21 +56,21 @@ Voici les caractéristiques de chacun des états pour les boutons primaires :
 
 **État normal** : Couleur primaire à 100 % d’opacité, texte blanc avec une bordure d’un rayon de 4px et d’un remplissage de 15px.
 
-<button style="margin-top: 5px;" color="primary">Normal</button>
+<button aria-label="Exemple d'un bouton primaire en état normal" style="margin-top: 5px;" color="primary">Normal</button>
 
 <codeblock html='<button type="button" class="btn btn-primary">Normal</button>' react='<Button color="primary">Normal</Button>'></codeblock>
 
 **État stationnaire** : Couleur primaire à 80 % d’opacité, texte blanc avec une bordure d’un rayon de 4px et d’un remplissage de 15px.
 
-<button color="primary" style="color: #fff; background-color: #245e83; border-color: #215679">Stationnaire</button>
+<button aria-label="Exemple d'un bouton primaire en état sensitif" color="primary" style="color: #fff; background-color: #245e83; border-color: #215679">Stationnaire</button>
 
 **État accentué** : Couleur primaire à 80 % d’opacité, texte blanc avec une bordure d’un rayon de 4px et d’un remplissage de 15px. Comprends un trait de 3px dans une couleur primaire.
 
-<button color="primary" style="outline: 1px dotted; outline: 5px auto -webkit-focus-ring-color;">Accentué</button>
+<button aria-label="Exemple d'un bouton primaire en état accentué" color="primary" style="background-color: #002D42; box-shadow: 0 0 0 0.2rem rgba(0, 45, 66, 0.25);">Accentué</button>
 
 **État désactivé** : Couleur primaire à 60 % d’opacité, texte blanc avec une bordure d’un rayon de 4px et d’un remplissage de 15px.
 
-<button color="primary" disabled="true">Désactivé</button>
+<button aria-label="Exemple d'un bouton primaire en état désactivé" color="primary" disabled="true">Désactivé</button>
 
 <codeblock html='<button type="button" class="btn btn-primary" disabled>Primaire</button>' react='<Button color="primary" disabled>Désactivé</Button>'></codeblock>
 
@@ -88,21 +88,23 @@ Les boutons secondaires dans ce système sont transparents avec une couleur de t
 
 Voici les caractéristiques de chacun des états pour les boutons :
 
-**État normal** : Transparent avec un trait de 1px utilisant la couleur <badge style="background-color: #002D42;color:black;">##002D42</badge>, le texte est écrit dans la même couleur. La bordure est d’un rayon de 4px et le remplissage de 15px.
+**État normal** : Transparent avec un trait de 1px utilisant la couleur <badge style="background-color: #002D42;color:white;">#002D42</badge>, le texte est écrit dans la même couleur. La bordure est d’un rayon de 4px et le remplissage de 15px.
 
-<button color="secondary">Secondaire</button>
+<button aria-label="Exemple d'un bouton secondaires en état normal" color="secondary">Secondaire</button>
 
 <codeblock html='<button type="button" class="btn btn-secondary">Secondaire</button>' react='<Button color="secondary">Secondaire</Button>'></codeblock>
 
 **État sensitif** : Un rectangle coloré avec no002D42 à 80 % d’opacité, le texte est écrit en blanc. La bordure est d’un rayon de 4px et le remplissage de 15px.
 
-**État accentué** : Transparent avec un trait de 3px utilisant no002D42, le texte est écrit en <badge style="background-color: #002D42;color:black;">##002D42</badge>. La bordure est d’un rayon de 4px et le remplissage de 15px.
+<button aria-label="Exemple d'un bouton secondaires en état sensitif" color="secondary" style="color: #fff; background-color: #002D42;">Sensitif</button>
 
-<button color="secondary" style="color: #fff; background-color: #087a84; border-color: #1e4f6f;box-shadow: 0 0 0 0.2rem rgba(44, 115, 161, 0.25), inset 0 3px 5px rgba(0, 0, 0, 0.125);">Accentué</button>
+**État accentué** : Transparent avec un trait de 3px utilisant no002D42, le texte est écrit en <badge style="background-color: #002D42;color:white;">#002D42</badge>. La bordure est d’un rayon de 4px et le remplissage de 15px.
+
+<button aria-label="Exemple d'un bouton secondaires en état accentué" color="secondary" style="color: #002D42; background-color: transparent; box-shadow: 0 0 0 0.2rem rgba(0, 45, 66, 0.25);">Accentué</button>
 
 **État désactivé** : Remplissage de couleur <badge style="background-color: #CECECE;color:black;">#CECECE</badge> avec du texte blanc. La bordure est d’un rayon de 4px et le remplissage de 15px.
 
-<button color="secondary" disabled="true">Secondaire</button>
+<button aria-label="Exemple d'un bouton secondaires en état désactivé" color="secondary" disabled="true">Secondaire</button>
 
 <codeblock html='<button type="button" class="btn btn-secondary" disabled>Secondaire</button>' react='<Button color="secondary" disabled>Secondaire</Button>'></codeblock>
 
@@ -150,7 +152,7 @@ Cliquer sur les boutons de menu déroulant affiche une liste d’éléments. Ces
 
 **État activé** : Lorsqu’on presse sur la flèche du menu déroulant, cette section du bouton est affichée à 80 % d’opacité et un menu déroulant est affiché en dessous. La boîte d’action utilise une bordure de 1px de couleur <badge style="background-color: #CECECE;color:black;">#CECECE</badge>. La boîte a une bordure d’un rayon de 4px. La largeur de la boîte est de 166px et la hauteur dépend du nombre d’actions, utilisant 40px par action. Lorsque le curseur est placé dessus, le 40px autour de l’action est affiché en utilisant <badge style="background-color: #CECECE;color:black;">#CECECE</badge>.
 
-<mdbuttondropdown color="primary" style="outline: 1px dotted; outline: 5px auto -webkit-focus-ring-color;" title="Accentué">
+<mdbuttondropdown color="primary" style=" box-shadow: 0 0 0 0.2rem rgba(0, 45, 66, 0.25);" title="Accentué">
 </mdbuttondropdown>
 
 **État activé** : Lorsqu’on presse sur la flèche du menu déroulant, cette section du bouton est affichée à 80 % d’opacité et un menu déroulant est affiché en dessous. La boîte d’action utilise une bordure de 1px de couleur <badge style="background-color: #CECECE;color:black;">#CECECE</badge>. La boîte a une bordure d’un rayon de 4px. La largeur de la boîte est de 166px et la hauteur dépend du nombre d’actions, utilisant 40px par action. Lorsque le curseur est placé dessus, le 40px autour de l’action est affiché en utilisant <badge style="background-color: #CECECE;color:black;">#CECECE</badge>.

--- a/src/docs/fr/component/indicateurs d'etat.md
+++ b/src/docs/fr/component/indicateurs d'etat.md
@@ -51,32 +51,32 @@ Les barres de progression sont stylisées au moyen d’un rectangle d’environ 
 Le pourcentage peut être soit aligné à la droite de la barre, soit centré dans la portion colorée de la barre.
 
 <div class="progress">
-  <div class="progress-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
+  <div class="progress-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">0%</div>
 </div>
 
 <codeblock html='
     <div class="progress">
-        <div class="progress-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
+        <div class="progress-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">0%</div>
     </div>
 ' react='' />
 
 <div class="progress">
-  <div class="progress-bar" role="progressbar" style="width: 75%" aria-valuenow="75" aria-valuemin="0" aria-valuemax="100"></div>
+  <div class="progress-bar" role="progressbar" style="width: 75%" aria-valuenow="75" aria-valuemin="0" aria-valuemax="100">75%</div>
 </div>
 
 <codeblock html='
     <div class="progress">
-        <div class="progress-bar" role="progressbar" style="width: 75%" aria-valuenow="75" aria-valuemin="0" aria-valuemax="100"></div>
+        <div class="progress-bar" role="progressbar" style="width: 75%" aria-valuenow="75" aria-valuemin="0" aria-valuemax="100">75%</div>
     </div>
 ' react='' />
 
 <div class="progress">
-  <div class="progress-bar" role="progressbar" style="width: 100%" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100"></div>
+  <div class="progress-bar" role="progressbar" style="width: 100%" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100">100%</div>
 </div>
 
 <codeblock html='
     <div class="progress">
-        <div class="progress-bar" role="progressbar" style="width: 100%" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100"></div>
+        <div class="progress-bar" role="progressbar" style="width: 100%" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100">100%</div>
     </div>
 ' react='' />
 
@@ -90,9 +90,9 @@ Les barres de progression sont vides au début et se remplissent graduellement d
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 </helmet>
-<i class="fa fa-circle-o-notch fa-spin" style="font-size:24px"></i>
-<i class="fa fa-refresh fa-spin" style="font-size:24px"></i>
-<i class="fa fa-spinner fa-spin" style="font-size:24px"></i>
+<i class="fa fa-circle-o-notch fa-spin" style="font-size:24px"><span class="sr-only">Notch circle spinner</span></i>
+<i class="fa fa-refresh fa-spin" style="font-size:24px"><span class="sr-only">Refresh spinner</span></i>
+<i class="fa fa-spinner fa-spin" style="font-size:24px"><span class="sr-only">Dot spinner</span></i>
 
 Les boucles de progression sont utilisées pour indiquer le chargement d’une page ou d’une fonction. Une règle générale est d’utiliser des boucles de progression pour les processus qui durent moins de 4 secondes. Les boucles de progression indiquent des niveaux de progrès indéterminés, ce qui signifie qu’il n’y a pas d’achèvement clair et que la boucle d’animation se poursuit jusqu’à ce que le processus soit terminé.
 

--- a/src/docs/fr/component/indicateurs d'etat.md
+++ b/src/docs/fr/component/indicateurs d'etat.md
@@ -90,10 +90,10 @@ Les barres de progression sont vides au début et se remplissent graduellement d
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 </helmet>
-<i class="fa fa-circle-o-notch fa-spin" style="font-size:24px"><span class="sr-only">Notch circle spinner</span></i>
-<i class="fa fa-refresh fa-spin" style="font-size:24px"><span class="sr-only">Refresh spinner</span></i>
-<i class="fa fa-spinner fa-spin" style="font-size:24px"><span class="sr-only">Dot spinner</span></i>
+<i class="fa fa-circle-o-notch fa-spin" style="font-size:24px"><span class="sr-only">Exemple d'une girouette circulaire</span></i>
+<i class="fa fa-refresh fa-spin" style="font-size:24px"><span class="sr-only">Exemple d'une girouette pour rafraîchir</span></i>
+<i class="fa fa-spinner fa-spin" style="font-size:24px"><span class="sr-only">Exemple d'une girouette avec des points</span></i>
 
 Les boucles de progression sont utilisées pour indiquer le chargement d’une page ou d’une fonction. Une règle générale est d’utiliser des boucles de progression pour les processus qui durent moins de 4 secondes. Les boucles de progression indiquent des niveaux de progrès indéterminés, ce qui signifie qu’il n’y a pas d’achèvement clair et que la boucle d’animation se poursuit jusqu’à ce que le processus soit terminé.
 
-La boucle de progression utilisée dans ce système de conception est affichée au moyen de l’icône de boucle de progression de la police Awesome. La police Awesome possède de multiples icônes qui pourraient bien fonctionner comme boucle de progression, selon votre contenu. Vous pouvez consulter la [documentation sur la police Awesome]((https://www.gitbook.com/book/gctools-outilsgc/-gcdigital-design-system/edit)) afin d’animer la boucle de pression pour démontrer le chargement d’une page ou d’une fonction.
+La boucle de progression utilisée dans ce système de conception est affichée au moyen de l’icône de boucle de progression de la police Awesome. La police Awesome possède de multiples icônes qui pourraient bien fonctionner comme boucle de progression, selon votre contenu. Vous pouvez consulter la [documentation sur la police Awesome](https://fontawesome.com/how-to-use/on-the-web/styling/animating-icons) afin d’animer la boucle de pression pour démontrer le chargement d’une page ou d’une fonction.

--- a/src/docs/fr/data/donnees_ choisir les visualizations.md
+++ b/src/docs/fr/data/donnees_ choisir les visualizations.md
@@ -13,8 +13,6 @@ title: "Choisir les visualizations"
 
 ## Tableaux
 
-<strippedtable></strippedtable>
-
 Les tableaux constituent le format brut pour la publication des jeux de données. Si une visualisation plus complexe est utilisée, un tableau devrait également se trouver quelque part sur la page afin que les utilisateurs puissent choisir la façon dont ils affichent et analysent les données.
 
 Les tableaux peuvent être tout ce dont vous avez besoin pour visualiser vos données. Il est formidable d’utiliser un tableau si :

--- a/src/docs/fr/data/donnees_ tableaux.md
+++ b/src/docs/fr/data/donnees_ tableaux.md
@@ -29,6 +29,7 @@ Rangée d’en-têtes : les en-têtes du tableau sont affichés en en-tête 6 (N
 
 Cellule du tableau : l’information de la cellule du tableau est affichée en utilisant un style de texte normal (Nunito sans régulier à 16px) et est alignée à gauche. Le texte a un remplissage de 21px par 27px. La rangée d’en-têtes a une bordure inférieure de 2px utilisant la couleur <badge style="background-color: #96a8b2; color:black">#96A8B2</badge>. Chaque rangée a une bordure inférieure de 1px utilisant la couleur <badge style="background-color: #96a8b2; color:black">#96A8B2</badge>.
 
+<h3>Exemple de tableau simple</h3>
 <table class="table">
   <thead>
     <tr>
@@ -90,7 +91,7 @@ Cellule du tableau : l’information de la cellule du tableau est affichée en u
             <td>@twitter</td>
             </tr>
         </tbody>
-    </table> 
+    </table>
 ' react=''></codeblock>
 
 ## Tableau rayé
@@ -107,6 +108,7 @@ Cellule du tableau : l’information de la cellule du tableau est affichée en u
 
 Chaque seconde rangée a un remplissage de <badge style="background-color: #F2F5F6; color:black">#F2F5F6</badge>.
 
+<h3>Exemple de tableau rayé</h3>
 <strippedtable></strippedtable>
 
 <codeblock html='


### PR DESCRIPTION
Added more context to examples on buttons, spinners and tables pages.

Closes #97 
Closes #90 