### PR TITLE
Usability changes to pages

### DIFF
--- a/src/components/header.js
+++ b/src/components/header.js
@@ -60,7 +60,7 @@ const Header = ({ path }) => {
             </div>
           </div>
           <div>
-            <Navbar color="white" expand className="main-nav" style={{paddingBottom:'0'}} aria-label={t("MainNavigation")} role="navigation">
+            <Navbar color="white" expand className="main-nav" style={{paddingBottom:'0', paddingRight:'0'}} aria-label={t("MainNavigation")} role="navigation">
               <Link to="/#!" className="text-dark logo">
                 <img src={logo} alt="Logo" className="float-left" style={{width:'30px', margin:'5px'}} />
                 <span className="h2 d-none d-md-block float-left font-weight-normal">

--- a/src/components/sidenav.js
+++ b/src/components/sidenav.js
@@ -54,7 +54,7 @@ class Sidenav extends React.Component {
       <I18n ns={["translation"]}>
         {
           (t, { i18n }) => (
-            <nav id="sidenav" role="navigation" aria-label={t("SubNavigation")}>
+            <nav class="sidenav" role="navigation" aria-label={t("SubNavigation")}>
               <Nav style={{'marginTop':'110px', 'marginBottom':'40px'}}>
                 {subPieces}
               </Nav>

--- a/src/components/sidenav.scss
+++ b/src/components/sidenav.scss
@@ -1,4 +1,4 @@
-#sidenav{
+.sidenav{
   background-color: #FAFAFA;
   display: inline-block;
   max-width: 300px;
@@ -28,7 +28,7 @@
 }
 
 @media (max-width: 768px) {
-  .mobile-sidebar #sidenav {
+  .mobile-sidebar .sidenav {
       top: 161px !important;
       z-index:9999;
       .nav {

--- a/src/layouts/layout.scss
+++ b/src/layouts/layout.scss
@@ -1,3 +1,11 @@
+/* Proper anchor link fpcus */
+:target::before {
+  content: "";
+  display: block;
+  height: 110px;
+  margin: -110px 0 0;
+}
+
 #container{
   margin-left: 0px !important;
   height: 100%;
@@ -113,6 +121,12 @@ position:fixed;
       .lead {
         max-width:100%;
       }
+  }
+  :target::before {
+    content: "";
+    display: block;
+    height: 170px;
+    margin: -170px 0 0;
   }
 
 }


### PR DESCRIPTION
Multiple changes to pages to fix some usability issues. 
  - Same page anchor links now appear below main navigation instead of underneath
  - Added extra style to mobile version of main navigation to help user see that more links are present an
  - Removed duplicate html IDs on sidenav component

Did not work on the codeblock element at all, will consider doing that work when we transition to tab page layout.

Closes #87 
Closes https://github.com/gctools-outilsgc/design-system/issues/217
Closes https://github.com/gctools-outilsgc/design-system/issues/221