### PR TITLE
Added gatsbyjs-remark-prismjs for consistent codeblocks

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -46,6 +46,16 @@ module.exports = {
               linkImagesToOriginal: false,
             },
           },
+          {
+            resolve: `gatsby-remark-prismjs`,
+            options: {
+              classPrefix: "language-",
+              inlineCodeMarker: null,
+              aliases: {},
+              showLineNumbers: false,
+              noInlineHighlight: false,
+            },
+          },
         ],
       },
     },

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "gatsby-plugin-react-helmet": "^2.0.11",
     "gatsby-plugin-sass": "^1.0.26",
     "gatsby-remark-images": "latest",
+    "gatsby-remark-prismjs": "^3.1.4",
     "gatsby-source-filesystem": "latest",
     "gatsby-transformer-remark": "latest",
     "gatsby-transformer-sharp": "latest",

--- a/src/layouts/layout.scss
+++ b/src/layouts/layout.scss
@@ -44,6 +44,10 @@
   background:#467B8D;
 }
 
+.gatsby-highlight {
+  margin: 10px;
+}
+
 @media (max-width: 768px) {
   .doc-container {
       padding-left: 15px;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4410,6 +4410,14 @@ gatsby-remark-images@latest:
     slash "^1.0.0"
     unist-util-select "^1.5.0"
 
+gatsby-remark-prismjs@^3.1.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/gatsby-remark-prismjs/-/gatsby-remark-prismjs-3.1.4.tgz#c19875f2a4e2d882f6df350c6d8e834a64f0066c"
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    parse-numeric-range "^0.0.2"
+    unist-util-visit "^1.3.0"
+
 gatsby-source-filesystem@latest:
   version "1.5.39"
   resolved "https://registry.yarnpkg.com/gatsby-source-filesystem/-/gatsby-source-filesystem-1.5.39.tgz#c7e49b7809632b53c827e66ff3ee0ba74ef62dd8"
@@ -7715,6 +7723,10 @@ parse-latin@^4.0.0:
     unist-util-modify-children "^1.0.0"
     unist-util-visit-children "^1.0.0"
 
+parse-numeric-range@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/parse-numeric-range/-/parse-numeric-range-0.0.2.tgz#b4f09d413c7adbcd987f6e9233c7b4b210c938e4"
+
 parse-passwd@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/parse-passwd/-/parse-passwd-1.0.0.tgz#6d5b934a456993b23d37f40a382d6f1666a8e5c6"
@@ -10951,7 +10963,7 @@ unist-util-visit-parents@^2.0.0:
   dependencies:
     unist-util-is "^2.1.2"
 
-unist-util-visit@^1.0.0, unist-util-visit@^1.1.0, unist-util-visit@^1.1.1:
+unist-util-visit@^1.0.0, unist-util-visit@^1.1.0, unist-util-visit@^1.1.1, unist-util-visit@^1.3.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-1.4.0.tgz#1cb763647186dc26f5e1df5db6bd1e48b3cc2fb1"
   dependencies:


### PR DESCRIPTION
While working on documentation we discovered our codeblock component freaks out often. For the time being we will use gatsbyjs-rework-prismjs to create codeblocks. Unfortunately we will lose the copy button for now but will be added back in the future. 