### PR TITLE
fix: broken cover image links

### DIFF
--- a/src/docs/en/component/cards.md
+++ b/src/docs/en/component/cards.md
@@ -230,7 +230,7 @@ A second divider is placed 12px below the content. Actionable items (i.e. button
 Cards can technically include any number of component combinations. Using the base styles above, components such as placeholder text (metadata), avatars, icon buttons, buttons can be added below the header, or within the actionable section below the main content.
 
 <div class="card card-profile mb-2 d-inline-block" style="max-width: 18rem;">  
-    <img class="card-img-top" style="height: 100px;" src="http://coverpixs.com/images/items/itm_2013-01-27_11-36-29_1.jpg" alt="placeholder image">
+    <img class="card-img-top" style="height: 100px;" src="https://web.archive.org/web/20131221155650if_/http://coverpixs.com/images/items/itm_2013-01-27_11-36-29_1.jpg" alt="placeholder image">
     <div class="card-body">
         <img alt="..." class="avatar avatar-lg" src="https://avataaars.io/?avatarStyle=Circle&topType=LongHairStraight2&accessoriesType=Wayfarers&hairColor=Black&facialHairType=Blank&clotheType=BlazerSweater&eyeType=Default&eyebrowType=RaisedExcitedNatural&mouthType=Default&skinColor=Yellow">
         <div>

--- a/src/docs/fr/component/cartes.md
+++ b/src/docs/fr/component/cartes.md
@@ -231,7 +231,7 @@ Un deuxième diviseur de 12px est placé sous le contenu. Des points actionnable
 Les cartes peuvent techniquement comprendre un certain nombre de combinaisons d’éléments. En utilisant les concepts de base qui précèdent, les éléments comme les espaces de texte réservés (métadates), les avatars, les boutons icônes et les boutons peuvent être ajoutés sous l’en-tête ou dans la section actionnable en dessous du contenu principal.
 
 <div class="card card-profile mb-2 d-inline-block" style="max-width: 18rem;">  
-    <img class="card-img-top" alt="placeholder image" style="height: 100px;" src="http://coverpixs.com/images/items/itm_2013-01-27_11-36-29_1.jpg">
+    <img class="card-img-top" alt="placeholder image" style="height: 100px;" src="https://web.archive.org/web/20131221155650if_/http://coverpixs.com/images/items/itm_2013-01-27_11-36-29_1.jpg">
     <div class="card-body">
         <img alt="..." class="avatar avatar-lg" src="https://avataaars.io/?avatarStyle=Circle&topType=LongHairStraight2&accessoriesType=Wayfarers&hairColor=Black&facialHairType=Blank&clotheType=BlazerSweater&eyeType=Default&eyebrowType=RaisedExcitedNatural&mouthType=Default&skinColor=Yellow">
         <div>


### PR DESCRIPTION
- The old link for the cover image is broken so card looks broken currently.
![image](https://github.com/gctools-outilsgc/aurora-website/assets/70106102/adfe03dc-96b3-41f9-95c3-d33ecb451f8c)

- Here is the fixed one
![image](https://github.com/gctools-outilsgc/aurora-website/assets/70106102/fea12176-677a-4c92-8cb3-66df288fe886)
